### PR TITLE
Added support for winston's built-in formatter function

### DIFF
--- a/lib/winston-logrotate.js
+++ b/lib/winston-logrotate.js
@@ -33,6 +33,8 @@ var Rotate = exports.Rotate = function (options) {
     this.keep = options.keep || DEFAULT_KEEP;
     this.compress = typeof(options.compress) === 'undefined' ? DEFAULT_COMPRESS : options.compress;
 
+    this.formatter = options.formatter;
+
     this.ready = false;
 };
 
@@ -71,7 +73,8 @@ Rotate.prototype.log = function (level, msg, meta, callback) {
         meta: meta,
         stringify: this.stringify,
         timestamp: this.timestamp,
-        prettyPrint: this.prettyPrint
+        prettyPrint: this.prettyPrint,
+        formatter: this.formatter
     });
 
     if (this.ready) {


### PR DESCRIPTION
Added reference for the `formatter` transport parameter found in winston so as to support its [usage](https://www.npmjs.com/package/winston#custom-log-format) in this extension. In regular winston transports this works like so:

```
var logger = new (winston.Logger)({
  transports: [
    new (winston.transports.Console)({
      timestamp: function() {
        return Date.now();
      },
      formatter: function(options) {
        // Return string will be passed to logger. 
        return options.timestamp() +' '+ options.level.toUpperCase() +' '+ (options.message ? options.message : '') +
          (options.meta && Object.keys(options.meta).length ? '\n\t'+ JSON.stringify(options.meta) : '' );
      }
    })
  ]
});
```
And now it should work with `winston.transports.Rotate` as well.