### PR TITLE
fixed redirection to file transport instead of console

### DIFF
--- a/lib/winston-logrotate.js
+++ b/lib/winston-logrotate.js
@@ -127,13 +127,6 @@ Rotate.prototype._configure_log_stream = function (resolve, reject) {
     });
 
     log_stream.on('ready', function () {
-        process.__defineGetter__('stdout', function () {
-            return log_stream;
-        });
-        process.__defineGetter__('stderr', function () {
-            return log_stream;
-        });
-
         self.ready = true;
         self.emit('ready', log_stream);
         resolve();


### PR DESCRIPTION
The following lines regarding the `stdout` and `stderror`
```
        process.__defineGetter__('stdout', function () {
            return log_stream;
        });
        process.__defineGetter__('stderr', function () {
            return log_stream;
        });
```
were removed from the event
````
    log_stream.on('ready', function () {
````

And issue #4 appears to be fixed without any breaking changes. Was unable to verify with the automated tests however, unit testing looked good.