### PR TITLE
>= Winston Version

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "bluebird": "2.9.30",
     "fs-extra": "0.24.0",
     "logrotate-stream": "0.2.5",
-    "winston": "2.1.0"
+    "winston": "^2.1.0"
   },
   "devDependencies": {
     "bluebird-retry": "0.4.0",


### PR DESCRIPTION
Use the latest version of winston rather than a fixed version so that behavior is consistent and the library works as intended against the actual winston instance in the app