### PR TITLE
avoid open file handle limit by saving writes

### DIFF
--- a/lib/winston-logrotate.js
+++ b/lib/winston-logrotate.js
@@ -15,7 +15,7 @@ var DEFAULT_KEEP = 5;
 
 var DEFAULT_COMPRESS = true;
 
-var DEFAULT_STRINGIFY = (obj) => {return JSON.stringify(obj);};
+var DEFAULT_STRINGIFY = function(obj){ return JSON.stringify(obj); };
 
 var Rotate = exports.Rotate = function (options) {
     Transport.call(this, options);

--- a/lib/winston-logrotate.js
+++ b/lib/winston-logrotate.js
@@ -86,11 +86,11 @@ Rotate.prototype.log = function (level, msg, meta, callback) {
 
     if (this.state == 'uninitialized') {
       this.state = 'initializing';
-      pendingWrites[this.file] = [{ level, output, callback }];
+      pendingWrites[this.file] = [{ level: level, output: output, callback: callback }];
       this._init();
     } else {
       if (this.state == 'initializing') {
-        pendingWrites[this.file].push({ level, output, callback });
+        pendingWrites[this.file].push({ level: level, output: output, callback: callback });
       } else {
         self._write(level, output, callback);
       }

--- a/lib/winston-logrotate.js
+++ b/lib/winston-logrotate.js
@@ -35,7 +35,7 @@ var Rotate = exports.Rotate = function (options) {
 
     this.formatter = options.formatter;
 
-    this.ready = false;
+    this.state = 'uninitialized'
 };
 
 //
@@ -62,6 +62,9 @@ Rotate.prototype.name = 'rotate';
 // #### @callback {function} Continuation to respond to when complete.
 // Core logging method exposed to Winston. Metadata is optional.
 //
+
+var pendingWrites = {}
+
 Rotate.prototype.log = function (level, msg, meta, callback) {
     var self = this;
 
@@ -77,14 +80,16 @@ Rotate.prototype.log = function (level, msg, meta, callback) {
         formatter: this.formatter
     });
 
-    if (this.ready) {
-        this._write(level, output, callback);
+    if (this.state == 'uninitialized') {
+      this.state = 'initializing';
+      pendingWrites[this.file] = [{ level, output, callback }];
+      this._init();
     } else {
-        this._init().done(function () {
-            self._write(level, output, callback);
-        }, function (err) {
-            throw err;
-        });
+      if (this.state == 'initializing') {
+        pendingWrites[this.file].push({ level, output, callback });
+      } else {
+        self._write(level, output, callback);
+      }
     }
 };
 
@@ -98,7 +103,6 @@ Rotate.prototype.close = function() {
 
 Rotate.prototype._write = function (level, output, callback) {
     var self = this;
-
     this.log_stream.write(output + '\n', function () {
         self.emit('logged');
         callback(null, true);
@@ -127,8 +131,17 @@ Rotate.prototype._configure_log_stream = function (resolve, reject) {
     });
 
     log_stream.on('ready', function () {
-        self.ready = true;
+        self.state = 'ready'
         self.emit('ready', log_stream);
+
+        if (self.file in pendingWrites) {
+          for (var i = 0; i < pendingWrites[self.file].length; ++i) {
+            var pendingWrite = pendingWrites[self.file][i]
+            self._write(pendingWrite.level, pendingWrite.output, pendingWrite.callback);
+          }
+          delete pendingWrites[self.file]
+        }
+
         resolve();
     });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "winston-logrotate",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Log rotating transport for Winston",
   "keywords": [
     "winston",

--- a/test/winston-logrotate.spec.js
+++ b/test/winston-logrotate.spec.js
@@ -158,4 +158,20 @@ describe('winston logrotate tests', function () {
 
         recursive_log(6);
     });
+
+    it('max file handles', function(done) {
+      this.timeout(10000)
+      var temp_dir = temp.mkdirSync('winston-logrotate-test');
+      var file = path.join(temp_dir, 'rotate.log');
+      var logger = new Rotate({
+          file: file,
+          size: '1k',
+          keep: 1
+      });
+
+      for (let i = 0; i < 100000; ++ i) {
+        logger.log('max log test');
+      }
+      done();
+    })
 });

--- a/test/winston-logrotate.spec.js
+++ b/test/winston-logrotate.spec.js
@@ -169,7 +169,7 @@ describe('winston logrotate tests', function () {
           keep: 1
       });
 
-      for (let i = 0; i < 100000; ++ i) {
+      for (var i = 0; i < 100000; ++ i) {
         logger.log('max log test');
       }
       done();


### PR DESCRIPTION
Avoid calling init() repeatedly when logging in a loop, see "ulimit open file handles reached #14" in open issues for more details.